### PR TITLE
pcie: accept MHI_EE_FP (ee=7) as loader-already-running on re-entry

### DIFF
--- a/pcie.c
+++ b/pcie.c
@@ -192,6 +192,22 @@ static int pcie_upload_programmer(int port_index, const char *programmer_path)
 		 info->bhi_ee, info->bhi_sernum,
 		 info->bhi_ver_major, info->bhi_ver_minor);
 
+	/*
+	 * If the firehose loader is already resident (MHI_EE_FP, ee=7), the
+	 * device is in flashing-protocol mode and ready to accept firehose
+	 * commands on /dev/mhi_EDL. Skip the re-upload and return success so
+	 * the caller can open /dev/mhi_EDL directly. Without this, every
+	 * post-printgpt invocation (e.g. `qfenix readall -P` after a
+	 * truncated `qfenix printgpt -P`) bails with
+	 * "device not in EDL mode (ee=7, expected 6)" even though the loader
+	 * is alive — forcing a full EDL re-entry round-trip per qfenix call.
+	 */
+	if (info->bhi_ee == MHI_EE_FP) {
+		ux_info("loader already running (ee=FP), skipping re-upload\n");
+		rc = 0;
+		goto out;
+	}
+
 	if (info->bhi_ee != MHI_EE_EDL) {
 		ux_err("device not in EDL mode (ee=%u, expected %u)\n",
 		       info->bhi_ee, MHI_EE_EDL);


### PR DESCRIPTION
## Summary

`pcie_upload_programmer()` rejects any device whose BHI execution-environment is not `MHI_EE_EDL` (`ee=6`), printing:

```
device not in EDL mode (ee=7, expected 6)
```

…and bailing out. But `MHI_EE_FP` (`ee=7`, "Flash Programmer") is the legitimate state the device transitions into immediately after a successful firehose-loader upload. Once the loader is resident, the device is firehose-ready on `/dev/mhi_EDL` and a re-upload is both unnecessary and impossible (BHI `WRITEIMAGE` will fail).

This 5-line short-circuit accepts `MHI_EE_FP` as "loader is already running, skip the re-upload" so the caller can proceed straight to `/dev/mhi_EDL` open + firehose handshake.

## Why it matters

Without this, every qfenix invocation chained after an initial EDL entry has to drop the device back to `ee=6` — typically by issuing `AT+CFUN=1,1` and waiting ~30–60 seconds for the modem to reboot — before each subsequent firehose call. With it, sequences like:

```
qfenix printgpt -P -L tools/qfirehose/programmers/quectel-sdx62 -s nand -d
qfenix readall  -P -L tools/qfirehose/programmers/quectel-sdx62 -s nand -o <outdir>
```

…run back-to-back. The second invocation logs `loader already running (ee=FP), skipping re-upload` and proceeds immediately.

## Test plan

- [x] Validated on Quectel **RM520N-GL-AP** (SDX62 PCIe, OOT `pcie_mhi` driver, firmware `RM520NGLAAR01A05M4G_01.001.01.001`).
- [x] Reproduced the pre-patch bail-out: `qfenix readall -P` immediately after a truncated `qfenix printgpt -P` returns `device not in EDL mode (ee=7, expected 6)`.
- [x] Confirmed post-patch behavior: same sequence proceeds straight to firehose handshake.
- [x] Produced a clean **33-partition raw-NAND capture** (~513 MB) end-to-end with the patched binary — would otherwise have required N full EDL re-entries.

## Notes

- No change to the existing `MHI_EE_EDL` path — the new branch is purely additive ahead of the existing rejection.
- `MHI_EE_FP` is already defined in `pcie.h` (`= 0x7, /* Flash Programmer */`); no header change needed.
- Tested only on the SDX62 / `quectel-sdx62` programmer combination; the change is transport-state-only and should apply uniformly to any platform that exposes `/dev/mhi_BHI` + `/dev/mhi_EDL` with the standard MHI EE state machine.
