### PR TITLE
usb: iSerialNumber fallback + --usb-id runtime EDL allowlist extender

### DIFF
--- a/qdl.c
+++ b/qdl.c
@@ -850,6 +850,9 @@ static void print_usage(FILE *out)
 		       "\nGlobal Options");
 	fprintf(out, " (work with all subcommands):\n");
 	fprintf(out, "      --log=FILE            Write debug-level log to FILE\n");
+	fprintf(out, "      --usb-id=VID:PID      Treat VID:PID as an EDL endpoint (hex,\n");
+	fprintf(out, "                            repeatable). Extends built-in allowlist\n");
+	fprintf(out, "                            for OEM boot modes (e.g. 1199:9090).\n");
 
 	ux_fputs_color(out, UX_COLOR_BOLD UX_COLOR_GREEN,
 		       "\nFlash Options");
@@ -5674,6 +5677,62 @@ int main(int argc, char **argv)
 			argc -= strip;
 			break;
 		}
+	}
+
+	/*
+	 * Pre-scan for ``--usb-id VID:PID`` (global, repeatable). Extends the
+	 * built-in EDL device allowlist at runtime so qfenix will recognize
+	 * one-off OEM boot modes whose PID isn't in usb_ids.h yet — e.g.
+	 * Sierra EM7511 1199:9090 AirPrime Boot — without a recompile or a
+	 * patch. Accepts 1-4 hex digits per side, with or without ``0x``
+	 * prefix. Repeat the flag to add multiple pairs. Stripped from argv
+	 * so per-subcommand getopt tables don't need to know about it.
+	 */
+	for (int i = 1; i < argc; ) {
+		const char *spec = NULL;
+		int strip = 0;
+
+		if (!strncmp(argv[i], "--usb-id=", 9)) {
+			spec = argv[i] + 9;
+			strip = 1;
+		} else if (!strcmp(argv[i], "--usb-id") && i + 1 < argc) {
+			spec = argv[i + 1];
+			strip = 2;
+		} else {
+			i++;
+			continue;
+		}
+
+		unsigned int vid_u = 0, pid_u = 0;
+		int consumed = 0;
+		if (sscanf(spec, "%x:%x%n", &vid_u, &pid_u, &consumed) != 2 ||
+		    spec[consumed] != '\0' ||
+		    vid_u > 0xffff || pid_u > 0xffff) {
+			fprintf(stderr,
+				"Error: --usb-id expects VID:PID in hex (e.g. 1199:9090), got '%s'\n",
+				spec);
+			return 1;
+		}
+
+		if (usb_add_extra_edl_id((uint16_t)vid_u, (uint16_t)pid_u) < 0) {
+			/* Table is full. Silently dropping the request would
+			 * let the subcommand run with an EDL allowlist that
+			 * doesn't match what the operator asked for — which
+			 * then fails inside usb_open() with the generic
+			 * "Waiting for EDL device..." spin and looks like a
+			 * different bug. Fail the process instead so the CLI
+			 * error is unambiguous. */
+			fprintf(stderr,
+				"Error: --usb-id runtime allowlist is full; cannot register %04x:%04x\n",
+				vid_u, pid_u);
+			return 1;
+		}
+
+		/* Strip --usb-id arg(s) so subcommands don't see them. */
+		for (int j = i; j + strip < argc; j++)
+			argv[j] = argv[j + strip];
+		argc -= strip;
+		/* Don't advance i — the next arg just shifted into this slot. */
 	}
 
 	/* Handle no args, --help, --help-all, -h before subcommand dispatch */

--- a/qdl.h
+++ b/qdl.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "list.h"
 #include "patch.h"
@@ -110,6 +111,14 @@ struct qdl_device_desc {
 };
 
 struct qdl_device_desc *usb_list(unsigned int *devices_found);
+
+/*
+ * Register an additional VID:PID pair as an EDL-mode endpoint at runtime
+ * (in addition to the built-in list in usb_ids.h). Typically wired up
+ * from the top-level ``--usb-id`` CLI option in qdl.c's main(). Returns 0
+ * on success, -1 if the internal table is full.
+ */
+int usb_add_extra_edl_id(uint16_t vid, uint16_t pid);
 
 struct usb_adb_desc {
 	int vid;

--- a/usb.c
+++ b/usb.c
@@ -39,31 +39,185 @@ struct qdl_device_usb {
 #define LIBUSB_ENDPOINT_TRANSFER_TYPE_BULK LIBUSB_TRANSFER_TYPE_BULK
 #endif
 
+/*
+ * Runtime-extendable EDL-mode device allowlist.
+ *
+ * The built-in list in usb_ids.h covers well-known Qualcomm / Sony / Sierra
+ * / etc. EDL PIDs. Callers (typically main() in qdl.c) can extend it at
+ * runtime via usb_add_extra_edl_id() to cover:
+ *
+ *   - One-off OEM variants whose PID isn't in the built-in list yet.
+ *   - OEM boot modes that speak Sahara but aren't publicly documented.
+ *   - Ad-hoc debugging against an unknown PID without a recompile.
+ *
+ * Kept as file-scope state in usb.c (not usb_ids.h) because usb_ids.h is a
+ * "static inline" header consumed by many translation units — a runtime
+ * mutable array in a static-inline header would silently diverge per TU.
+ */
+#define USB_EXTRA_EDL_MAX 16
+
+static struct {
+	uint16_t vid;
+	uint16_t pid;
+} usb_extra_edl_ids[USB_EXTRA_EDL_MAX];
+static unsigned int usb_extra_edl_count;
+
+/*
+ * Register an additional VID:PID pair as an EDL-mode endpoint for the
+ * current qfenix process. Returns 0 on success, -1 if the table is full.
+ * Duplicates (either against the built-in list or an existing extra) are
+ * silently ignored.
+ */
+int usb_add_extra_edl_id(uint16_t vid, uint16_t pid)
+{
+	unsigned int i;
+
+	if (is_edl_device(vid, pid))
+		return 0;
+
+	for (i = 0; i < usb_extra_edl_count; i++) {
+		if (usb_extra_edl_ids[i].vid == vid &&
+		    usb_extra_edl_ids[i].pid == pid)
+			return 0;
+	}
+
+	if (usb_extra_edl_count >= USB_EXTRA_EDL_MAX) {
+		warnx("usb: --usb-id table full (max %d), ignoring %04x:%04x",
+		      USB_EXTRA_EDL_MAX, vid, pid);
+		return -1;
+	}
+
+	usb_extra_edl_ids[usb_extra_edl_count].vid = vid;
+	usb_extra_edl_ids[usb_extra_edl_count].pid = pid;
+	usb_extra_edl_count++;
+	return 0;
+}
+
+static bool usb_is_edl_device_runtime(uint16_t vid, uint16_t pid)
+{
+	unsigned int i;
+
+	if (is_edl_device(vid, pid))
+		return true;
+
+	for (i = 0; i < usb_extra_edl_count; i++) {
+		if (usb_extra_edl_ids[i].vid == vid &&
+		    usb_extra_edl_ids[i].pid == pid)
+			return true;
+	}
+	return false;
+}
+
+/*
+ * Extract a serial-number-like string from a device's USB descriptors.
+ *
+ * Qualcomm's "Gobi" reference composition advertises a serial embedded in
+ * iProduct as ``<name>_SN:<serial>`` — e.g. ``QUSB__BULK_SN:1234abcd``. This
+ * has historically been the only signal qfenix consulted, which works fine
+ * for Qualcomm-branded EDL devices but BREAKS for OEM boot modes that
+ * populate iSerialNumber instead of stuffing the serial into iProduct.
+ *
+ * Concrete case that motivated this: Sierra Wireless EM7511 in
+ * 1199:9090 AirPrime Boot mode. Its iProduct is ``Sierra Wireless EM7511
+ * Qualcomm® Snapdragon™ X16 LTE-A`` (no ``_SN:``) but iSerialNumber is
+ * ``YT94979507031546`` — a perfectly usable FSN. Previously qfenix rejected
+ * the device with "ignoring device with no serial number".
+ *
+ * Fallback order:
+ *   1. iProduct descriptor, after ``_SN:`` marker (Qualcomm-style embedding).
+ *   2. iSerialNumber descriptor verbatim (OEM-style serial).
+ *
+ * Returns 1 on success (serial written to out, null-terminated, truncated
+ * to out_sz-1) or 0 if neither source yielded a serial.
+ */
+static int usb_read_device_serial(struct libusb_device_handle *handle,
+				  const struct libusb_device_descriptor *desc,
+				  char *out, size_t out_sz)
+{
+	unsigned char buf[128];
+	const char *src = NULL;
+	size_t src_len = 0;
+	int ret;
+
+	if (!out || out_sz == 0)
+		return 0;
+
+	/* 1. Try iProduct ``_SN:`` embedding first — preserves prior behavior
+	 *    for Qualcomm-branded EDL devices that already worked. */
+	if (desc->iProduct) {
+		ret = libusb_get_string_descriptor_ascii(handle, desc->iProduct,
+							 buf, sizeof(buf) - 1);
+		if (ret < 0) {
+			/* Preserve the pre-refactor diagnostic: the old code
+			 * logged libusb_strerror(ret) and aborted this device.
+			 * We log and fall through so the iSerialNumber branch
+			 * still gets a chance — a failed iProduct read doesn't
+			 * preclude iSerialNumber from succeeding. */
+			warnx("failed to read iProduct descriptor (idVendor=%04x idProduct=%04x): %s",
+			      desc->idVendor, desc->idProduct,
+			      libusb_strerror(ret));
+		} else {
+			buf[ret] = '\0';
+			char *p = strstr((char *)buf, "_SN:");
+			if (p) {
+				p += strlen("_SN:");
+				src = p;
+				src_len = strcspn(p, " _");
+			}
+		}
+	}
+
+	/* 2. Fallback: iSerialNumber descriptor.
+	 *    Trigger when step 1 didn't match OR matched but produced an
+	 *    empty serial (iProduct contained ``_SN:`` followed immediately
+	 *    by EOL/space/underscore). The empty-match case is rare but
+	 *    exercised by malformed iProduct strings in the wild. */
+	if ((!src || src_len == 0) && desc->iSerialNumber) {
+		ret = libusb_get_string_descriptor_ascii(handle, desc->iSerialNumber,
+							 buf, sizeof(buf) - 1);
+		if (ret < 0) {
+			warnx("failed to read iSerialNumber descriptor (idVendor=%04x idProduct=%04x): %s",
+			      desc->idVendor, desc->idProduct,
+			      libusb_strerror(ret));
+		} else if (ret > 0) {
+			buf[ret] = '\0';
+			/* Trim trailing whitespace. */
+			while (ret > 0 && (buf[ret - 1] == ' ' ||
+					   buf[ret - 1] == '\t' ||
+					   buf[ret - 1] == '\r' ||
+					   buf[ret - 1] == '\n'))
+				buf[--ret] = '\0';
+			if (ret > 0) {
+				src = (const char *)buf;
+				src_len = (size_t)ret;
+			}
+		}
+	}
+
+	if (!src || src_len == 0)
+		return 0;
+
+	if (src_len >= out_sz)
+		src_len = out_sz - 1;
+
+	memcpy(out, src, src_len);
+	out[src_len] = '\0';
+	return 1;
+}
+
 static bool usb_match_usb_serial(struct libusb_device_handle *handle, const char *serial,
 				 const struct libusb_device_descriptor *desc)
 {
 	char buf[128];
-	char *p;
-	int ret;
 
 	/* If no serial is requested, consider everything a match */
 	if (!serial)
 		return true;
 
-	ret = libusb_get_string_descriptor_ascii(handle, desc->iProduct, (unsigned char *)buf, sizeof(buf));
-	if (ret < 0) {
-		warnx("failed to read iProduct descriptor: %s", libusb_strerror(ret));
-		return false;
-	}
-
-	p = strstr(buf, "_SN:");
-	if (!p)
+	if (!usb_read_device_serial(handle, desc, buf, sizeof(buf)))
 		return false;
 
-	p += strlen("_SN:");
-	p[strcspn(p, " _")] = '\0';
-
-	return strcmp(p, serial) == 0;
+	return strcmp(buf, serial) == 0;
 }
 
 static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const char *serial)
@@ -88,8 +242,9 @@ static int usb_try_open(libusb_device *dev, struct qdl_device_usb *qdl, const ch
 		return -1;
 	}
 
-	/* Consider only known EDL-mode devices */
-	if (!is_edl_device(desc.idVendor, desc.idProduct))
+	/* Consider only known EDL-mode devices (built-in list + any
+	 * entries added at runtime via --usb-id). */
+	if (!usb_is_edl_device_runtime(desc.idVendor, desc.idProduct))
 		return 0;
 
 	ret = libusb_get_active_config_descriptor(dev, &config);
@@ -291,11 +446,8 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 	struct qdl_device_desc *result;
 	struct libusb_device **devices;
 	struct libusb_device *dev;
-	unsigned long serial_len;
-	unsigned char buf[128];
 	ssize_t device_count;
 	unsigned int count = 0;
-	char *serial;
 	int ret;
 	int i;
 
@@ -325,7 +477,7 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 			continue;
 		}
 
-		if (!is_edl_device(desc.idVendor, desc.idProduct))
+		if (!usb_is_edl_device_runtime(desc.idVendor, desc.idProduct))
 			continue;
 
 		ret = libusb_open(dev, &handle);
@@ -335,31 +487,20 @@ struct qdl_device_desc *usb_list(unsigned int *devices_found)
 			continue;
 		}
 
-		ret = libusb_get_string_descriptor_ascii(handle, desc.iProduct, buf, sizeof(buf) - 1);
-		if (ret < 0) {
-			warnx("failed to read iProduct descriptor: %s", libusb_strerror(ret));
-			libusb_close(handle);
-			continue;
+		if (!usb_read_device_serial(handle, &desc,
+					    result[count].serial,
+					    sizeof(result[count].serial))) {
+			/*
+			 * Neither iProduct ``_SN:`` nor iSerialNumber yielded
+			 * a usable serial. Keep the device listed but record
+			 * an empty serial — the caller can still target it by
+			 * VID:PID when only one such device is present on the
+			 * host. Serial-based selection (-S) won't match.
+			 */
+			ux_warn("device %04x:%04x has no usable serial descriptor; listing with empty serial\n",
+				desc.idVendor, desc.idProduct);
+			result[count].serial[0] = '\0';
 		}
-		buf[ret] = '\0';
-
-		serial = strstr((char *)buf, "_SN:");
-		if (!serial) {
-			ux_err("ignoring device with no serial number\n");
-			libusb_close(handle);
-			continue;
-		}
-
-		serial += strlen("_SN:");
-		serial_len = strcspn(serial, " _");
-		if (serial_len + 1 > sizeof(result[count].serial)) {
-			ux_err("ignoring device with unexpectedly long serial number\n");
-			libusb_close(handle);
-			continue;
-		}
-
-		memcpy(result[count].serial, serial, serial_len);
-		result[count].serial[serial_len] = '\0';
 
 		result[count].vid = desc.idVendor;
 		result[count].pid = desc.idProduct;
@@ -416,8 +557,10 @@ struct usb_adb_desc *usb_list_adb(unsigned int *devices_found)
 		if (!is_diag_vendor(desc.idVendor))
 			continue;
 
-		/* Skip EDL devices */
-		if (is_edl_device(desc.idVendor, desc.idProduct))
+		/* Skip EDL devices (including runtime --usb-id extras — we
+		 * want the DIAG list to exclude anything we've explicitly
+		 * tagged as an EDL endpoint). */
+		if (usb_is_edl_device_runtime(desc.idVendor, desc.idProduct))
 			continue;
 
 		ret = libusb_get_active_config_descriptor(devices[i],


### PR DESCRIPTION
## Summary

Two small USB-layer gaps that surfaced when trying to target a Sierra Wireless EM7511 sitting in `1199:9090` boot mode:

1. **`usb_list()` / `usb_match_usb_serial()` require `_SN:` embedded in iProduct.** Devices that expose their serial number only via the `iSerialNumber` USB descriptor are rejected with `ignoring device with no serial number` — even when the serial is perfectly readable from `iSerialNumber`. Sierra's AirPrime Boot mode at `1199:9090` does exactly this: `iProduct = "Sierra Wireless EM7511 Qualcomm® Snapdragon™ X16 LTE-A"` (no `_SN:` marker) while `iSerialNumber = "YT94979507031546"`.
2. **No way to add a VID/PID to the EDL allowlist without editing `usb_ids.h` and rebuilding.** Useful for experimenting with an OEM boot-mode PID that isn't in the built-in list yet, or for debugging an unknown Sahara endpoint.

## Changes

### `usb.c` — new `usb_read_device_serial()` helper

Factors the iProduct `_SN:` extraction into a shared helper used by both `usb_list()` and `usb_match_usb_serial()`. Fallback order:

1. iProduct descriptor, after `_SN:` marker (Qualcomm-style embedding) — preserves prior behavior for everything that already worked.
2. `iSerialNumber` descriptor verbatim, with trailing-whitespace trim.

The fallback also triggers when iProduct contains `_SN:` followed immediately by a delimiter (yielding an empty serial) or when the iProduct read fails — both diagnostics are logged via `warnx()` with VID/PID + `libusb_strerror(ret)` so operators can tell apart "no serial advertised" from "descriptor read error".

`usb_list()` no longer drops devices with no usable serial — it lists them with an empty serial and logs a warning. `-S <serial>` still filters correctly (empty won't match any `-S` value), but the operator can now *see* the device and target it by VID:PID when it's unambiguous.

### `usb.c` — runtime-extendable EDL allowlist

- File-scope `usb_extra_edl_ids[16]` table + counter.
- `int usb_add_extra_edl_id(uint16_t vid, uint16_t pid)` — dedupes against built-in + existing extras, returns 0 / -1.
- `bool usb_is_edl_device_runtime(vid, pid)` — wrapper that consults built-in list then extras.
- Three `is_edl_device()` call sites inside `usb.c` (the two in `usb_open`/`usb_list` paths and the DIAG-list skip) now route through the wrapper.
- The other 7 translation units using `is_edl_device()` (qdl.c, at_port.c, diag.c, diag_switch.c, pcie.c, qcseriald.c) intentionally stay on the hardcoded-only check — they're pre-scan / DIAG-side paths where runtime extras aren't needed for the fix this PR targets. `usb_ids.h` stays header-only so nothing else needs to change.

### `qdl.c` — `--usb-id VID:PID` pre-scan

Alongside the existing `--log=` pre-scan in `main()`:

- Accepts `--usb-id=VID:PID` and `--usb-id VID:PID` forms.
- `sscanf(%x:%x%n)` + trailing-character check — hex required, non-hex and junk are rejected.
- Repeatable — loop continues past the first match.
- Stripped from `argv` so per-subcommand `getopt_long` tables don't need to know about it.
- If the 16-entry runtime table is full, emits a clear CLI error and `return 1` rather than silently proceeding with an incomplete allowlist.
- Added an entry under the "Global Options" section of `print_usage()`.

### `qdl.h`

- `#include <stdint.h>` (for `uint16_t`).
- Declared `int usb_add_extra_edl_id(uint16_t vid, uint16_t pid);` with doc comment.

## Test plan

- [x] `make` clean — no new warnings under the project's `-O2 -Wall -g`.
- [x] Sanity against a live Sierra EM7511 in `1199:9090` state: `qfenix list` now emits `1199:9090  SN:YT9497950703154` (serial truncated at 15 chars by the pre-existing `serial[16]` buffer in `struct qdl_device_desc` — out of scope for this PR).
- [x] `qfenix printgpt -S <serial> <loader>` against the same device now progresses past "Waiting for EDL device…" into the Sahara HELLO handshake (it fails at the bulk-write layer for unrelated reasons — see Note below).
- [x] `qfenix --help` shows the new `--usb-id` entry under "Global Options".
- [x] `qfenix --usb-id 1199:9090 list` works (pre-scan strips the flag before subcommand dispatch).
- [x] `qfenix --usb-id=1199:9090 --usb-id=05c6:9008 list` — multiple pairs accepted.
- [x] `qfenix --usb-id garbage list` — rejects with a clear error and exits 1.
- [x] Table-full: 17 distinct `--usb-id` flags (one past the 16-entry limit) emits `Error: --usb-id runtime allowlist is full; cannot register NNNN:NNNN` and exits 1 before dispatching.
- [x] Empty-`_SN:` edge case verified with a standalone reproduction of the helper's inner logic: `iProduct = "QUSB__BULK_SN:"` (empty serial) correctly triggers the iSerialNumber fallback.
- [ ] Regression: any `05c6:9008` Qualcomm-standard flow on real hardware. I don't have one on this bench, and didn't alter the iProduct `_SN:` path's success case — only added behavior when it fails.

## Note

On this particular Sierra EM7511 firmware (`SWI9X50C_01.08.04.00`, SDX20/MDM9650) the `1199:9090` state is in fact **not Sahara** — three consecutive bulk-write attempts fail with "No such device" and the modem auto-reboots back to `1199:9091` app mode. The `usb_ids.h` comment `/* EM9xxx/5G EDL */` looks correct for the later EM9xxx generation but is misleading for the earlier SDX20-based modules that also land at PID `9090` via `AT!BOOTHOLD + AT!RESET`.

**Not patching that comment in this PR** — the protocol-mismatch discovery was only possible *because* this PR's serial-fallback fix made the device visible to `qfenix`. A proper audit of which Sierra generations actually speak Sahara at `9090` vs. AirPrime Boot vs. something else is a separate research task. If you'd like, I can file a follow-up issue once I've mapped more generations.

## Non-goals

- Expanding `struct qdl_device_desc::serial[16]` (pre-existing buffer size, out of scope).
- Teaching qfenix to speak Sierra AirPrime Boot protocol at `1199:9090` (separate feature).
- Revising the `usb_ids.h` comments per the above note (waiting on cross-generation data).