### PR TITLE
Improve diagnostics and error handling for EFS operations under Windows

### DIFF
--- a/diag.c
+++ b/diag.c
@@ -1590,6 +1590,29 @@ out:
 	return ret;
 }
 
+/*
+ * Lower bound for a "looks plausible" EFS factory-image dump.
+ * Real EFS partitions are megabytes; the original report observed a
+ * 517-byte stub being treated as success because the read loop exited
+ * on the very first stream_state==0 response without ever transferring
+ * a payload byte.  Anything below this threshold is almost certainly
+ * a stub / handshake-only failure mode and should fail-fast rather
+ * than mislead the operator.
+ */
+#define EFS_DUMP_MIN_PLAUSIBLE_BYTES	(16 * 1024)
+
+/*
+ * Lower bounds for a "looks plausible" XQCN backup.  Even a freshly
+ * SPC-defaulted unit returns a handful of NV items (manufacturer ID,
+ * firmware version, default RF calibration, etc.) and a handful of
+ * EFS files (system paths, default config). Below these floors the
+ * backup is almost certainly the no-NV / no-EFS / handshake-only
+ * failure mode where each per-item probe printed "DIAG read failed"
+ * but the outer walk swallowed the failures and continued.
+ */
+#define XQCN_MIN_NV_ITEMS	5
+#define XQCN_MIN_EFS_FILES	5
+
 int diag_efs_dump(struct diag_session *sess, const char *output_file)
 {
 	uint8_t cmd[64];
@@ -1598,6 +1621,7 @@ int diag_efs_dump(struct diag_session *sess, const char *output_file)
 	int n;
 	int ret = -1;
 	uint8_t stream_state;
+	size_t bytes_written = 0;
 
 	if (!sess->efs_detected) {
 		n = diag_efs_detect(sess);
@@ -1654,6 +1678,7 @@ int diag_efs_dump(struct diag_session *sess, const char *output_file)
 				ux_err("write failed: %s\n", strerror(errno));
 				goto out;
 			}
+			bytes_written += (size_t)(n - 12);
 		}
 
 		if (stream_state == 0)
@@ -1665,11 +1690,26 @@ int diag_efs_dump(struct diag_session *sess, const char *output_file)
 	efs_cmd_header(cmd, sess->efs_method, EFS2_DIAG_FACT_IMAGE_END);
 	diag_send(sess, cmd, 4, resp, sizeof(resp));
 
-	ux_info("EFS dump complete: %s\n", output_file);
+	/*
+	 * Sanity-check the captured payload before claiming success.  See
+	 * EFS_DUMP_MIN_PLAUSIBLE_BYTES rationale above.
+	 */
+	if (bytes_written < EFS_DUMP_MIN_PLAUSIBLE_BYTES) {
+		ux_err("EFS dump output is implausibly small (%zu bytes, "
+		       "expected ≥ %u) — modem likely returned an empty "
+		       "factory image. Treating as failure.\n",
+		       bytes_written, (unsigned)EFS_DUMP_MIN_PLAUSIBLE_BYTES);
+		goto out;
+	}
+
+	ux_info("EFS dump complete: %s (%zu bytes)\n",
+		output_file, bytes_written);
 	ret = 0;
 
 out:
 	close(fd);
+	if (ret != 0)
+		(void)unlink(output_file);
 	return ret;
 }
 
@@ -4314,6 +4354,45 @@ int diag_efs_backup_xqcn(struct diag_session *sess, const char *output_file)
 
 	fprintf(fp, "</Storage>\n");
 	fclose(fp);
+
+	/*
+	 * Sanity-check capture totals before claiming success.  The original
+	 * report observed an exit-0 outcome on a run that produced 8000+
+	 * "DIAG read failed" lines on stderr because each individual probe
+	 * failure prints but does not abort the walk.  The minimum thresholds
+	 * below catch the no-NV / no-EFS / handshake-only failure modes
+	 * without rejecting genuinely-tiny captures (a zeroed-out unit still
+	 * has a few NV items).
+	 */
+	{
+		int total_nv = def_nv.count + sim1_nv.count;
+		int total_efs = efs_data.count;
+		int rc = 0;
+
+		if (total_nv < XQCN_MIN_NV_ITEMS) {
+			ux_err("XQCN backup captured only %d NV item(s) "
+			       "(expected ≥ %d) — modem likely failed to "
+			       "respond to the NV scan. Treating as failure.\n",
+			       total_nv, XQCN_MIN_NV_ITEMS);
+			rc = -1;
+		}
+		if (total_efs < XQCN_MIN_EFS_FILES) {
+			ux_err("XQCN backup captured only %d EFS file(s) "
+			       "(expected ≥ %d) — EFS tree walk likely "
+			       "failed. Treating as failure.\n",
+			       total_efs, XQCN_MIN_EFS_FILES);
+			rc = -1;
+		}
+
+		if (rc != 0) {
+			(void)unlink(output_file);
+			nv_scan_result_free(&def_nv);
+			nv_scan_result_free(&sim1_nv);
+			xqcn_efs_free(&efs_data);
+			path_set_free(&seen);
+			return rc;
+		}
+	}
 
 	ux_info("XQCN backup complete: %s\n", output_file);
 	ux_info("  NV items: %d default, %d SIM_1\n",

--- a/diag.c
+++ b/diag.c
@@ -716,8 +716,31 @@ int diag_offline(struct diag_session *sess)
 
 int diag_online(struct diag_session *sess)
 {
+	int ret;
+
+	/*
+	 * Issue the mode change first, then log truthfully based on the
+	 * outcome.  On some firmwares (observed: Quectel SDX62
+	 * RM520NGLAAR01A05M4G_01.001.01.001) DIAG_MODE_ONLINE is accepted
+	 * by the firmware but does NOT actually return CFUN to 1 — the
+	 * modem stays at +CFUN: 7 at the AT surface.  An unconditional
+	 * "switching modem back to online mode" log line in that case
+	 * misleads the operator into thinking recovery happened when it
+	 * didn't.  Recovery in practice requires AT+CFUN=1,1 on a paired
+	 * AT port followed by ~35s settle, OR the DIAG_MODE_RESET path
+	 * already used by the XQCN-restore call site below.
+	 */
+	ret = diag_set_mode(sess, DIAG_MODE_ONLINE);
+	if (ret) {
+		ux_warn("failed to switch modem back to online mode "
+			"(DIAG_MODE_ONLINE rejected) — modem may be left "
+			"at CFUN=7; recover with AT+CFUN=1,1 on the paired "
+			"AT port and wait ~35s\n");
+		return ret;
+	}
+
 	ux_info("switching modem back to online mode\n");
-	return diag_set_mode(sess, DIAG_MODE_ONLINE);
+	return 0;
 }
 
 /*

--- a/qdl.c
+++ b/qdl.c
@@ -4467,28 +4467,96 @@ static int qdl_efsrestore(int argc, char **argv)
 	return !!ret;
 }
 
+/*
+ * Parse argv for a [-o <file>] flag pair plus a single positional input
+ * argument.  Both subcommands xqcn2tar and tar2xqcn use this shape and
+ * previously hit a parser quirk where `-o` was treated as a positional
+ * output filename (e.g. `xqcn2tar in.xqcn -o out.tar` wrote to a file
+ * literally named "-o" and silently ignored "out.tar").
+ *
+ * Accepts:
+ *   <input>                       (output defaults to *default_output)
+ *   <input> <output>              (legacy positional form)
+ *   <input> -o <output>           (flag form, matches efsbackup/efsdump)
+ *   -o <output> <input>           (flag-first form)
+ *
+ * On success, *input and *output point into argv (input is required;
+ * output falls back to default_output if neither form supplied one).
+ * Returns 0 on success, -1 on a parse error (e.g. duplicate -o, -o
+ * without a value, multiple positional inputs).
+ */
+static int parse_in_out(int argc, char **argv, const char *default_output,
+			const char **input, const char **output)
+{
+	const char *in = NULL;
+	const char *out = NULL;
+	int i;
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
+			if (out) {
+				fprintf(stderr,
+					"error: -o specified more than once\n");
+				return -1;
+			}
+			if (i + 1 >= argc) {
+				fprintf(stderr,
+					"error: -o requires a filename\n");
+				return -1;
+			}
+			out = argv[++i];
+		} else if (in) {
+			fprintf(stderr,
+				"error: unexpected extra positional argument "
+				"'%s' (already have input '%s'). If you meant "
+				"to set the output file, use -o.\n",
+				argv[i], in);
+			return -1;
+		} else {
+			in = argv[i];
+		}
+	}
+
+	if (!in) {
+		fprintf(stderr, "error: missing input filename\n");
+		return -1;
+	}
+
+	*input = in;
+	*output = out ? out : default_output;
+	return 0;
+}
+
 static void print_xqcn2tar_help(FILE *out)
 {
 	extern const char *__progname;
 
-	fprintf(out, "Usage: %s xqcn2tar <input.xqcn> [output.tar]\n", __progname);
+	fprintf(out, "Usage: %s xqcn2tar <input.xqcn> [-o <output.tar>]\n", __progname);
 	fprintf(out, "\nConvert XQCN backup to TAR archive (offline, no device needed).\n");
 	fprintf(out, "NV items are stored as nv_items/NNNNN.bin in the TAR.\n");
+	fprintf(out, "\nIf -o is omitted, output defaults to 'output.tar'.\n");
+	fprintf(out, "Legacy positional form `<input> <output>` is also accepted.\n");
 	fprintf(out, "\nExamples:\n");
 	fprintf(out, "  %s xqcn2tar backup.xqcn\n", __progname);
+	fprintf(out, "  %s xqcn2tar backup.xqcn -o my_backup.tar\n", __progname);
 	fprintf(out, "  %s xqcn2tar backup.xqcn my_backup.tar\n", __progname);
 }
 
 static int qdl_xqcn2tar(int argc, char **argv)
 {
+	const char *input;
+	const char *output;
+
 	if (argc < 2 || strcmp(argv[1], "-h") == 0 ||
 	    strcmp(argv[1], "--help") == 0) {
 		print_xqcn2tar_help(argc < 2 ? stderr : stdout);
 		return argc < 2 ? 1 : 0;
 	}
 
-	const char *input = argv[1];
-	const char *output = argc >= 3 ? argv[2] : "output.tar";
+	if (parse_in_out(argc, argv, "output.tar", &input, &output) < 0) {
+		print_xqcn2tar_help(stderr);
+		return 1;
+	}
 
 	return !!diag_xqcn_to_tar(input, output);
 }
@@ -4497,24 +4565,32 @@ static void print_tar2xqcn_help(FILE *out)
 {
 	extern const char *__progname;
 
-	fprintf(out, "Usage: %s tar2xqcn <input.tar> [output.xqcn]\n", __progname);
+	fprintf(out, "Usage: %s tar2xqcn <input.tar> [-o <output.xqcn>]\n", __progname);
 	fprintf(out, "\nConvert TAR archive to XQCN format (offline, no device needed).\n");
 	fprintf(out, "TAR entries under nv_items/ are converted to NV_ITEM_ARRAY.\n");
+	fprintf(out, "\nIf -o is omitted, output defaults to 'output.xqcn'.\n");
+	fprintf(out, "Legacy positional form `<input> <output>` is also accepted.\n");
 	fprintf(out, "\nExamples:\n");
 	fprintf(out, "  %s tar2xqcn backup.tar\n", __progname);
+	fprintf(out, "  %s tar2xqcn backup.tar -o my_backup.xqcn\n", __progname);
 	fprintf(out, "  %s tar2xqcn backup.tar my_backup.xqcn\n", __progname);
 }
 
 static int qdl_tar2xqcn(int argc, char **argv)
 {
+	const char *input;
+	const char *output;
+
 	if (argc < 2 || strcmp(argv[1], "-h") == 0 ||
 	    strcmp(argv[1], "--help") == 0) {
 		print_tar2xqcn_help(argc < 2 ? stderr : stdout);
 		return argc < 2 ? 1 : 0;
 	}
 
-	const char *input = argv[1];
-	const char *output = argc >= 3 ? argv[2] : "output.xqcn";
+	if (parse_in_out(argc, argv, "output.xqcn", &input, &output) < 0) {
+		print_tar2xqcn_help(stderr);
+		return 1;
+	}
 
 	return !!diag_tar_to_xqcn(input, output);
 }


### PR DESCRIPTION
This pull request introduces several important improvements to the modem diagnostic and backup tooling, focusing on better error detection, clearer operator feedback, and improved command-line usability. The main changes include adding sanity checks to prevent misleading success reports when EFS or XQCN backups are incomplete or failed, and refactoring argument parsing for offline conversion commands to support both legacy and flag-based output selection.

**Error detection and reporting improvements:**

* Added minimum size and item count checks to EFS and XQCN backup routines (`diag_efs_dump`, `diag_efs_backup_xqcn`) to detect handshake-only or failed backups, aborting and cleaning up the output file if thresholds are not met. [[1]](diffhunk://#diff-fea8ab6a91b257936dc05f681232055b3d5c824075a502d5d8f0a54d1fc22fc5R1593-R1615) [[2]](diffhunk://#diff-fea8ab6a91b257936dc05f681232055b3d5c824075a502d5d8f0a54d1fc22fc5L1645-R1712) [[3]](diffhunk://#diff-fea8ab6a91b257936dc05f681232055b3d5c824075a502d5d8f0a54d1fc22fc5R4358-R4396)
* Improved logging in `diag_online` to only report successful mode changes when actually confirmed, avoiding misleading operator messages on firmware where DIAG mode change does not restore full modem function.

**Command-line usability improvements:**

* Refactored the argument parsing for `xqcn2tar` and `tar2xqcn` commands in `qdl.c` to support both legacy positional and new `-o <output>` flag forms, preventing accidental misuse and clarifying help messages. [[1]](diffhunk://#diff-00a0298129c9a5db08949ba62663b21b5632793b00af31e6e3188c485f19625bR4470-R4559) [[2]](diffhunk://#diff-00a0298129c9a5db08949ba62663b21b5632793b00af31e6e3188c485f19625bL4500-R4593)

**Internal code improvements:**

* Tracked and reported the total bytes written during EFS dump operations for more informative completion messages and accurate threshold checks. [[1]](diffhunk://#diff-fea8ab6a91b257936dc05f681232055b3d5c824075a502d5d8f0a54d1fc22fc5R1624) [[2]](diffhunk://#diff-fea8ab6a91b257936dc05f681232055b3d5c824075a502d5d8f0a54d1fc22fc5R1681)

These changes collectively make the diagnostic and backup tools more robust, user-friendly, and resistant to silent failures.

Code was written by Claude, PR written by Copilot, snark was written by Luke.